### PR TITLE
Copy files from builder to runner in dockerfile

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -13,9 +13,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=cache \
-    cargo install sea-orm-cli
-
 RUN cargo build --release
 
 # runtime image

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,35 +1,15 @@
-# compile rust backend
-FROM rustlang/rust:nightly-bookworm AS builder
+FROM rustlang/rust:nightly-alpine3.21 AS builder
 
 COPY --link . /app
 WORKDIR /app
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y \
-    build-essential \
+RUN apk update && apk upgrade \
+    && apk add --no-cache \
+    alpine-sdk \
     libpq-dev \
-    libssl-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    pkgconfig \
+    && apk cache clean
 
 RUN cargo build --release
-
-# runtime image
-FROM debian:bookworm-slim AS runtime
-
-RUN apt-get update && apt-get install -y \
-    libpq5 \
-    ca-certificates \
-    postgresql-client \
-    libssl3 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
-
-COPY --from=builder /usr/local/cargo/bin/sea-orm-cli /usr/local/bin/
-COPY --from=builder /app/target ./target
-COPY . ./
 
 ENTRYPOINT ["/app/target/release/server"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,28 +1,38 @@
+# compile rust backend
 FROM rustlang/rust:nightly-bookworm AS builder
 
+COPY --link . /app
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
     build-essential \
     libpq-dev \
     libssl-dev \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install sea-orm-cli
-
-COPY . .
+RUN --mount=type=cache \
+    cargo install sea-orm-cli
 
 RUN cargo build --release
- 
-FROM debian:bookworm-slim
+
+# runtime image
+FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update && apt-get install -y \
     libpq5 \
     ca-certificates \
     postgresql-client \
     libssl3 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app
+
 COPY --from=builder /usr/local/cargo/bin/sea-orm-cli /usr/local/bin/
-CMD ["sh", "-c", "cd /app && sea-orm-cli migrate up -u $DATABASE_URL -d migration && target/release/project-loved"]
+COPY --from=builder /app/target ./target
+COPY . ./
+
+ENTRYPOINT ["/app/target/release/server"]


### PR DESCRIPTION
**The issue**

[`FROM` commands](https://docs.docker.com/reference/dockerfile/#from) starts a new build stage, and thus anything done in this stage will not carry out into any other stages. This checks out, because build stages are also ran in parallel.

---

Through some internal discussions I've decided to cut out the migration runner from `sea-orm-cli`. ~~however due to this fix I presume it would actually work this time around if it's added back in. If not, then we can cut the build time by 2m 15s by removing the installation of the CLI.~~